### PR TITLE
Metric type query

### DIFF
--- a/tensorhive/api/APIServer.py
+++ b/tensorhive/api/APIServer.py
@@ -3,9 +3,6 @@ import connexion
 from tensorhive.config import API_CONFIG
 from tensorhive.database import db_session
 from flask_cors import CORS
-from specsynthase.specbuilder import SpecBuilder
-from os import path
-import better_exceptions
 log = logging.getLogger(__name__)
 
 

--- a/tensorhive/api/APIServer.py
+++ b/tensorhive/api/APIServer.py
@@ -20,8 +20,10 @@ class APIServer():
             db_session.remove()
 
         app.add_api(API_CONFIG.SPECIFICATION_FILE,
-                    arguments={'title': API_CONFIG.TITLE},
-                    resolver=connexion.RestyResolver('tensorhive.api.api'),
+                    arguments={'title': API_CONFIG.TITLE,
+                               'version': API_CONFIG.VERSION},
+                    resolver=connexion.RestyResolver(
+                        API_CONFIG.VERSION_FOLDER),
                     strict_validation=True)
         CORS(app.app)
         app.run(server=API_CONFIG.SERVER_BACKEND,

--- a/tensorhive/api/APIServer.py
+++ b/tensorhive/api/APIServer.py
@@ -3,6 +3,9 @@ import connexion
 from tensorhive.config import API_CONFIG
 from tensorhive.database import db_session
 from flask_cors import CORS
+from specsynthase.specbuilder import SpecBuilder
+from os import path
+import better_exceptions
 log = logging.getLogger(__name__)
 
 

--- a/tensorhive/api/api/nodes.py
+++ b/tensorhive/api/api/nodes.py
@@ -12,20 +12,6 @@ def get_all_metrics():
 
 
 def get_gpu_metrics(hostname: str, metric_type: str = None):
-    query_to_key_mapping = {
-        'name': 'name',
-        'uuid': 'uuid',
-        'fan': 'fan.speed [%]',
-        'mem_free': 'memory.free [MiB]',
-        'mem_used': 'memory.used [MiB]',
-        'mem_total': 'memory.total [MiB]',
-        'util': 'utilization.gpu [%]',
-        'mem_util': 'utilization.memory [%]',
-        'temp': 'temperature.gpu',
-        'power': 'power.draw [W]'
-    }
-    if metric_type is not None:
-        metric_type = query_to_key_mapping[metric_type]
     return GetMetricsController.get(hostname=hostname,
                                     resource_type='GPU',
                                     metric_type=metric_type)

--- a/tensorhive/api/api/nodes.py
+++ b/tensorhive/api/api/nodes.py
@@ -11,9 +11,21 @@ def get_all_metrics():
     return GetMetricsController.all()
 
 
-def get_gpu_metrics(hostname):
-    return GetMetricsController.gpu(hostname=hostname, metric_type='GPU')
-
-
-def get_gpu_fan(hostname):
-    return GetMetricsController.get(hostname=hostname, metric_type='GPU', parameter_name='fan.speed [%]')
+def get_gpu_metrics(hostname: str, metric_type: str = None):
+    query_to_key_mapping = {
+        'name': 'name',
+        'uuid': 'uuid',
+        'fan': 'fan.speed [%]',
+        'mem_free': 'memory.free [MiB]',
+        'mem_used': 'memory.used [MiB]',
+        'mem_total': 'memory.total [MiB]',
+        'util': 'utilization.gpu [%]',
+        'mem_util': 'utilization.memory [%]',
+        'temp': 'temperature.gpu',
+        'power': 'power.draw [W]'
+    }
+    if metric_type is not None:
+        metric_type = query_to_key_mapping[metric_type]
+    return GetMetricsController.get(hostname=hostname,
+                                    resource_type='GPU',
+                                    metric_type=metric_type)

--- a/tensorhive/api/api/nodes.py
+++ b/tensorhive/api/api/nodes.py
@@ -12,4 +12,8 @@ def get_all_metrics():
 
 
 def get_gpu_metrics(hostname):
-    return GetMetricsController.get(hostname=hostname, metric_type='GPU')
+    return GetMetricsController.gpu(hostname=hostname, metric_type='GPU')
+
+
+def get_gpu_fan(hostname):
+    return GetMetricsController.get(hostname=hostname, metric_type='GPU', parameter_name='fan.speed [%]')

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -9,6 +9,9 @@ basePath: /v1.0
 paths:
   /users:
     get:
+      tags: 
+        - users
+      summary: Get all users
       responses:
         '200':
           description: 'All fetched with success.'
@@ -17,6 +20,9 @@ paths:
             items:
               $ref: '#/definitions/User'
     post:
+      tags: 
+        - users
+      summary: Create new user
       parameters:
         - in: body
           name: user
@@ -32,6 +38,9 @@ paths:
           description: 'Not registered due to an error.'
   /reservations:
     get:
+      tags: 
+        - reservations
+      summary: Get all reservation events
       responses:
         '200':
           description: 'All fetched with success.'
@@ -40,6 +49,9 @@ paths:
             items:
               $ref: '#/definitions/ReservationEvent'
     post:
+      tags: 
+        - reservations
+      summary: Create new reservation event
       parameters:
         - in: body
           name: reservation_event
@@ -53,6 +65,9 @@ paths:
           description: 'Not created due to an error.'
   '/reservations/{id}':
     delete:
+      tags: 
+          - reservations
+      summary: Delete reservation event by id
       parameters:
         - in: path
           name: id
@@ -66,6 +81,9 @@ paths:
   # TODO Nodes: Add more specific schemas, response codes + descriptions
   /nodes/hostnames:
     get:
+      tags: 
+        - nodes
+      summary: Get all hostnames
       operationId: 'tensorhive.api.api.nodes.get_hostnames'
       responses:
         '200':
@@ -76,6 +94,9 @@ paths:
               type: string
   /nodes/metrics:
     get:
+      tags: 
+        - nodes
+      summary: Get all metrics for each node
       operationId: 'tensorhive.api.api.nodes.get_all_metrics'
       responses:
         '200':
@@ -84,6 +105,9 @@ paths:
             type: object
   /nodes/{hostname}/metrics/gpu:
     get:
+      tags: 
+        - nodes
+      summary: Get GPU metrics for node with given id
       operationId: 'tensorhive.api.api.nodes.get_gpu_metrics'
       parameters:
         - in: path

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -35,7 +35,7 @@ paths:
         '409':
           description: 'Duplication error.'
         '500':
-          description: 'Not registered due to an error.'
+          $ref: '#/responses/InternalError'
   /reservations:
     get:
       tags: 
@@ -62,7 +62,7 @@ paths:
         '201':
           description: 'Successfully created.'
         '500':
-          description: 'Not created due to an error.'
+          $ref: '#/responses/InternalError'
   '/reservations/{id}':
     delete:
       tags: 
@@ -77,7 +77,7 @@ paths:
         '204':
           description: 'Successfully deleted.'
         '404':
-          description: 'Not found.'
+          $ref: '#/responses/NotFound'
   # TODO Nodes: Add more specific schemas, response codes + descriptions
   /nodes/hostnames:
     get:
@@ -120,7 +120,7 @@ paths:
             items: 
               type: object
         '404':
-          description: 'Hostname not found' 
+          $ref: '#/responses/NotFound'
 definitions:
   CreateUserController:
     type: object
@@ -170,34 +170,16 @@ definitions:
         type: string
         format: date-time
       # TODO Add user id, node id
-  Error:
-    type: object
-    properties:
-      code:
-        type: string
-      message:
-        type: string
-    required:
-      - code
-      - message
 
 responses:
-  # Created:
-  #   description: Resource created successfully
-  #   schema:
-  #     $ref: "#/definitions/Created"
+  # Example responses
+  # TODO Define more complex behaviour and use these reusable responses where possible (when API begins to stabilize)
   NotFound:
-    description: The specified resource was not found
-    schema:
-      $ref: "#/definitions/Error"
+    description: Resource was not found
   Unauthorized:
     description: Unauthorized
-    schema:
-      $ref: "#/definitions/Error"
   InternalError:
-    description: Internal Error
-    schema:
-      $ref: "#/definitions/Error"
+    description: Internal Server Error
 
 parameters:
   hostnameParam:

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -122,7 +122,26 @@ paths:
             items: 
               type: object
         '404':
-          description: 'Not found.'
+          description: 'Not found.' 
+  /nodes/{hostname}/metrics/gpu/fan:
+    get:
+      tags: 
+        - nodes
+      summary: TODO
+      operationId: 'tensorhive.api.api.nodes.get_gpu_fan'
+      parameters:
+        - in: path
+          name: hostname
+          required: true
+          type: string
+      responses:
+        '200':
+          description: TODO
+          schema:
+            type: integer
+        '404':
+          description: 'Not found.' 
+  
 definitions:
   CreateUserController:
     type: object

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -96,52 +96,31 @@ paths:
     get:
       tags: 
         - nodes
-      summary: Get all metrics for each node
+      summary: Get each node's all metric data
       operationId: 'tensorhive.api.api.nodes.get_all_metrics'
       responses:
         '200':
-          description: 'All metrics fetched with success.'
+          description: 'Success'
           schema:
             type: object
   /nodes/{hostname}/metrics/gpu:
     get:
       tags: 
         - nodes
-      summary: Get GPU metrics for node with given id
+      summary: Get node's GPU metric data
       operationId: 'tensorhive.api.api.nodes.get_gpu_metrics'
       parameters:
-        - in: path
-          name: hostname
-          required: true
-          type: string
+        - $ref: '#/parameters/hostnameParam'
+        - $ref: '#/parameters/gpuMetricTypeQuery'
       responses:
         '200':
-          description: 'List of GPU(s) metrics fetched with success.'
+          description: 'Success'
           schema:
             type: array
             items: 
               type: object
         '404':
-          description: 'Not found.' 
-  /nodes/{hostname}/metrics/gpu/fan:
-    get:
-      tags: 
-        - nodes
-      summary: TODO
-      operationId: 'tensorhive.api.api.nodes.get_gpu_fan'
-      parameters:
-        - in: path
-          name: hostname
-          required: true
-          type: string
-      responses:
-        '200':
-          description: TODO
-          schema:
-            type: integer
-        '404':
-          description: 'Not found.' 
-  
+          description: 'Hostname not found' 
 definitions:
   CreateUserController:
     type: object
@@ -191,3 +170,56 @@ definitions:
         type: string
         format: date-time
       # TODO Add user id, node id
+  Error:
+    type: object
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+    required:
+      - code
+      - message
+
+responses:
+  # Created:
+  #   description: Resource created successfully
+  #   schema:
+  #     $ref: "#/definitions/Created"
+  NotFound:
+    description: The specified resource was not found
+    schema:
+      $ref: "#/definitions/Error"
+  Unauthorized:
+    description: Unauthorized
+    schema:
+      $ref: "#/definitions/Error"
+  InternalError:
+    description: Internal Error
+    schema:
+      $ref: "#/definitions/Error"
+
+parameters:
+  hostnameParam:
+    description: Node's hostname in the network
+    in: path
+    name: hostname
+    required: true
+    type: string
+  gpuMetricTypeQuery:
+    description: Metric type. If not present, queries for all metrics
+    in: query
+    name: metric_type
+    required: false
+    type: string
+    enum:
+      - name
+      - uuid
+      - fan
+      - mem_free
+      - mem_used
+      - mem_total
+      - util
+      - mem_util
+      - temp
+      - power

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -197,11 +197,11 @@ parameters:
     enum:
       - name
       - uuid
-      - fan
+      - fan_speed
       - mem_free
       - mem_used
       - mem_total
-      - util
+      - gpu_util
       - mem_util
       - temp
       - power

--- a/tensorhive/api/api_specification.yml
+++ b/tensorhive/api/api_specification.yml
@@ -1,10 +1,10 @@
 swagger: "2.0"
 
 info:
-  title: "{{title}}"
-  version: "1.0"
+  title: "{{title}} v{{version}}"
+  version: "{{version}}"
 
-basePath: /v1.0
+basePath: "/v{{version}}"
 
 paths:
   /users:

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -25,8 +25,9 @@ class APIConfig():
 
     SPECIFICATION_FILE = 'api_specification.yml'
     # Indicates the location of folder containing api implementation (RustyResolver)
-    VERSION_FOLDER = 'api_v1'
+    VERSION_FOLDER = 'tensorhive.api.api'
     TITLE = 'TensorHive API'
+    VERSION = '1.0'
 
 
 class SSHConfig():

--- a/tensorhive/controllers/node/GetMetricsController.py
+++ b/tensorhive/controllers/node/GetMetricsController.py
@@ -9,10 +9,13 @@ class GetMetricsController:
         return infrastructure, 200
 
     @staticmethod
-    def get(hostname: str, metric_type: str):
+    def get(hostname: str, metric_type: str, parameter_name: str = None):
         try:
             infrastructure = TensorHiveManager().infrastructure_manager.infrastructure
             metrics = infrastructure[hostname][metric_type]
+
+            if parameter_name is not None:
+                metrics = [resource[parameter_name] for resource in metrics]
 
             # If some data is unavailable, return [] (e.g. monitoring service got a connection exception),
             if isinstance(metrics, dict) and metrics.keys() & ['exception', 'exit_code']:
@@ -22,3 +25,4 @@ class GetMetricsController:
             response = NoContent, 404
         finally:
             return response
+    

--- a/tensorhive/controllers/node/GetMetricsController.py
+++ b/tensorhive/controllers/node/GetMetricsController.py
@@ -9,13 +9,13 @@ class GetMetricsController:
         return infrastructure, 200
 
     @staticmethod
-    def get(hostname: str, metric_type: str, parameter_name: str = None):
+    def get(hostname: str, resource_type: str, metric_type: str = None):
         try:
             infrastructure = TensorHiveManager().infrastructure_manager.infrastructure
-            metrics = infrastructure[hostname][metric_type]
+            metrics = infrastructure[hostname][resource_type]
 
-            if parameter_name is not None:
-                metrics = [resource[parameter_name] for resource in metrics]
+            if metric_type is not None:
+                metrics = [resource[metric_type] for resource in metrics]
 
             # If some data is unavailable, return [] (e.g. monitoring service got a connection exception),
             if isinstance(metrics, dict) and metrics.keys() & ['exception', 'exit_code']:

--- a/tensorhive/core/utils/NvidiaSmiParser.py
+++ b/tensorhive/core/utils/NvidiaSmiParser.py
@@ -1,7 +1,25 @@
 from typing import Generator, Dict, List
+import logging
+log = logging.getLogger(__name__)
 
 
 class NvidiaSmiParser():
+
+    key_mapping = {
+        # keys: original nvidia-smi parameter names
+        # values: simpler and shorter form
+        'name': 'name',
+        'uuid': 'uuid',
+        'fan.speed [%]': 'fan_speed',
+        'memory.free [MiB]': 'mem_free',
+        'memory.used [MiB]': 'mem_used',
+        'memory.total [MiB]': 'mem_total',
+        'utilization.gpu [%]': 'gpu_util',
+        'utilization.memory [%]': 'mem_util',
+        'temperature.gpu': 'temp',
+        'power.draw [W]': 'power'
+    }
+
     @classmethod
     def _format_values(cls, values: List[str]):
         def formatted_value(value):
@@ -17,6 +35,19 @@ class NvidiaSmiParser():
         return [formatted_value(v) for v in values]
 
     @classmethod
+    def _renamed_keys(cls, original_keys: List[str]):
+        '''Replaces nvidia-smi query key names with more compact alternatives'''
+        try:
+            new_keys = [cls.key_mapping[original_key]
+                        for original_key in original_keys]
+            return new_keys
+        except KeyError as unexisting_key:
+            message = 'key mapping for {} not implemented!'.format(
+                unexisting_key)
+            log.critical(message)
+            raise KeyError(message)
+
+    @classmethod
     def gpus_info_from_stdout(cls, stdout: Generator) -> Dict[str, str]:
         '''
         Assumes nvidia-smi outputs with --format=csv (+must have a header)
@@ -25,17 +56,16 @@ class NvidiaSmiParser():
             {
                 "name": "GeForce GTX 660",
                 "uuid": "GPU-d38d4de3-85ee-e837-3d87-e8e2faeb6a63",
-                "fan.speed [%]": "33",
-                "memory.free [MiB]": "967",
-                "memory.used [MiB]": "1029",
-                "memory.total [MiB]": "1996",
-                "utilization.gpu [%]": null,
-                "utilization.memory [%]": null,
-                "temperature.gpu": "46",
-                "power.draw [W]": null
+                "fan_speed": 32,
+                "mem_free": 1329,
+                "mem_used": 667,
+                "mem_total": 1996,
+                "gpu_util": null,
+                "mem_util": null,
+                "temp": 44,
+                "power": null
             }
         ]
-
         '''
         stdout_lines = list(stdout)  # type: List[str]
         assert stdout_lines, 'stdout is empty!'
@@ -44,11 +74,12 @@ class NvidiaSmiParser():
         # Extract keys from nvidia-smi query result header
         header = stdout_lines[0]  # type: str
         gpu_parameters_keys = header.split(', ')  # type: List[str]
+        gpu_parameters_keys = cls._renamed_keys(gpu_parameters_keys)
 
         # Extract stdout lines, where:  1 line = 1 GPU
         all_gpus_stdout_lines = stdout_lines[1:]  # type: List[str]
 
-        # Result accumulator
+        # Define result accumulator
         all_gpus_info = []  # type:List[Dict[str, str]]
 
         # Transform stdout of a single GPU and append to accumulator


### PR DESCRIPTION
Issue #46

- Add optional query for endpoint:
```
allowed string values for metric_type are declared as enum, e.g. mem_util
/nodes/{hostname}/metrics/gpu?metric_type=...
/nodes/{hostname}/metrics/gpu -> all gpu metrics
```
- Add basic reusable responses and parameters