### PR TITLE
Inject custom logger to API server (gevent backend)

### DIFF
--- a/tensorhive/api/APIServer.py
+++ b/tensorhive/api/APIServer.py
@@ -8,6 +8,10 @@ from tensorhive.authorization import init_jwt
 log = logging.getLogger(__name__)
 
 
+class APILogger:
+    write = lambda message: log.debug(message)
+
+
 class APIServer():
     def run_forever(self):
         app = connexion.FlaskApp(__name__)
@@ -34,7 +38,8 @@ class APIServer():
         app.run(server=API_SERVER.BACKEND,
                 host=API_SERVER.HOST,
                 port=API_SERVER.PORT,
-                debug=API_SERVER.DEBUG)
+                debug=API_SERVER.DEBUG,
+                log=APILogger)
 
 
 def start_api_server():


### PR DESCRIPTION
Finally got the solution for #77 , directly from `connexion` contributor: 
https://github.com/zalando/connexion/issues/704#issuecomment-426493274

API server is now logging on debug level:
![image](https://user-images.githubusercontent.com/12485656/46560330-99ef3900-c8f3-11e8-8206-56504809ffea.png)
