### PR TITLE
Inject API URL into `config.json` dynamically at `tensorhive` startup.

### DIFF
--- a/tensorhive/app/web/AppServer.py
+++ b/tensorhive/app/web/AppServer.py
@@ -1,9 +1,11 @@
 from gunicorn.app.base import BaseApplication
 from flask import Flask, render_template
 from flask_cors import CORS
-from tensorhive.config import APP_SERVER
+from tensorhive.config import APP_SERVER, API_SERVER, API
 import webbrowser
 from tensorhive.core.utils.colors import green
+import json
+from pathlib import PosixPath
 import logging
 log = logging.getLogger(__name__)
 
@@ -39,10 +41,36 @@ class GunicornStandaloneApplication(BaseApplication):
         return self.application
 
 
+def _inject_api_endpoint_to_app():
+    '''
+    Allows for changing API URL that web app is sending requests to.
+    Web app expects API URL to be specified in `config.json`.
+    The file must not exist, it will be created automatically if needed.
+    '''
+    try:
+        web_app_json_config_path = PosixPath(__file__).parent / 'dist/static/config.json'
+        data = {
+            'apiPath': 'http://{}:{}/{}'.format(
+                API_SERVER.HOST,
+                API_SERVER.PORT,
+                API.URL_PREFIX)
+        }
+        # Overwrite current file content/create file if it does not exist
+        with open(str(web_app_json_config_path), 'w') as json_file:
+            json.dump(data, json_file)
+    except IOError as e:
+        log.error('Could inject API endpoint URL, reason: ' + str(e))
+    except Exception as e:
+        log.critical('Unknown error: ' + str(e))
+    else:
+        log.debug('API URL injected successfully: {}'.format(data))
+
+
 def start_server():
+    _inject_api_endpoint_to_app()
     log.info('[⚙] Starting Vue web app with {} backend'.format(
         APP_SERVER.BACKEND))
-    
+
     if APP_SERVER.BACKEND == 'gunicorn':
         options = {
             'bind': '{addr}:{port}'.format(addr=APP_SERVER.HOST, port=APP_SERVER.PORT),


### PR DESCRIPTION
This fix was required by web app.