### PR TITLE
Disable browser autolaunch. Remove all references to `webbrowser`

### DIFF
--- a/tensorhive/app/web/AppServer.py
+++ b/tensorhive/app/web/AppServer.py
@@ -2,7 +2,6 @@ from gunicorn.app.base import BaseApplication
 from flask import Flask, render_template
 from flask_cors import CORS
 from tensorhive.config import APP_SERVER, API_SERVER, API
-import webbrowser
 from tensorhive.core.utils.colors import green
 import json
 from pathlib import PosixPath
@@ -77,9 +76,7 @@ def start_server():
             'workers': APP_SERVER.WORKERS,
             'loglevel': APP_SERVER.LOG_LEVEL
         }
-        URL = 'http://' + options['bind']
-        log.info(green('[✔] Web App avaliable at: ' + URL))
-        webbrowser.open_new_tab(URL)
+        log.info(green('[✔] Web App avaliable at: http://' + options['bind']))
         GunicornStandaloneApplication(app, options).run()
     else:
         raise NotImplementedError('Selected backend is not supported yet.')


### PR DESCRIPTION
This feature was very annoying and useless on remote machines with no display.
In case we want this behavior back, we should consider using flags, like: `tensorhive --open-browser` or `tensorhive --no-browser` (depends on which behavior is default).