### PR TITLE
Introduce run-time checks for config files (+recreate missing files from templates)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,5 @@
 from setuptools import setup, find_packages
-from pathlib import PosixPath
 import tensorhive
-import shutil
-
-
-def copy_configuration_files():
-    target_dir = PosixPath.home() / '.config/TensorHive'
-    # destination is given explicitly, just in case we'd want to rename file during the installation process
-    hosts_config_path = {'src': 'hosts_config.ini', 'dst': str(target_dir / 'hosts_config.ini')}
-    config_path = {'src': 'main_config.ini', 'dst': str(target_dir / 'main_config.ini')}
-
-    def safe_copy(src: str, dst: str):
-        '''It won't override existing configuration'''
-        if PosixPath(dst).exists():
-            print('Skipping, file already exists: {}'.format(dst))
-        else:
-            shutil.copy(src, dst)
-            print('Creating file {}'.format(dst))
-
-    try:
-        target_dir.mkdir(parents=True, exist_ok=True)
-        safe_copy(hosts_config_path['src'], hosts_config_path['dst'])
-        safe_copy(config_path['src'], config_path['dst'])
-    except Exception:
-        # FIXME Prints are only visible with `pip install foobar --verbose`
-        print('Unable to copy configuration files to {}'.format(target_dir))
 
 
 # TODO Add platform and license
@@ -61,5 +36,3 @@ setup(
     ],
     zip_safe=False
 )
-
-copy_configuration_files()

--- a/tensorhive/cli.py
+++ b/tensorhive/cli.py
@@ -75,6 +75,7 @@ def log_level_mapping(ctx, param, value: str) -> int:
               type=click.Choice(AVAILABLE_LOG_LEVELS.keys()),
               callback=log_level_mapping,
               help='Log level to apply.')
+# TODO Allow using custom configuration from file: --config
 @click.pass_context
 def main(ctx, log_level):
     if ctx.invoked_subcommand is not None:

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -59,10 +59,10 @@ class ConfigLoader:
         config = configparser.ConfigParser(strict=False)
         full_path = PosixPath(path).expanduser()
         if config.read(str(full_path)):
-            log.info('[•] Reading {} config from {}'.format(displayed_title, path))
+            log.info('[•] Reading {} config from {}'.format(displayed_title, full_path))
         else:
-            log.warning('[✘] Missing configuration file ({})'.format(path))
-            log.warning('Using default settings from config.py')
+            log.warning('[✘] Configuration file not found ({})'.format(full_path))
+            log.info('Using default {} settings from config.py'.format(displayed_title))
         return config
 
 

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -5,8 +5,18 @@ import logging
 import tensorhive
 
 log = logging.getLogger(__name__)
-MAIN_CONFIG_PATH = '~/.config/TensorHive/main_config.ini'
 
+
+class CONFIG_FILES:
+    # TensorHive tries to load these by default
+    config_dir = PosixPath.home() / '.config/TensorHive'
+    MAIN_CONFIG_PATH = str(config_dir / 'main_config.ini')
+    HOSTS_CONFIG_PATH = str(config_dir / 'hosts_config.ini')
+
+    # Clone these files when default files are not found (and user does not)
+    tensorhive_package_dir = PosixPath(__file__).parent.parent
+    MAIN_CONFIG_TEMPLATE_PATH = str(tensorhive_package_dir / 'main_config.ini')
+    HOSTS_CONFIG_TEMPLATE_PATH = str(tensorhive_package_dir / 'hosts_config.ini')
 
 class ConfigLoader:
     @staticmethod

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -66,7 +66,8 @@ class ConfigLoader:
         return config
 
 
-config = ConfigLoader.load(MAIN_CONFIG_PATH, displayed_title='main')
+ConfigInitilizer()
+config = ConfigLoader.load(CONFIG_FILES.MAIN_CONFIG_PATH, displayed_title='main')
 
 
 def display_config(cls):
@@ -82,7 +83,7 @@ def display_config(cls):
 
 class SSH:
     section = 'ssh'
-    HOSTS_CONFIG_FILE = config.get(section, 'hosts_config_file', fallback='~/.config/TensorHive/hosts_config.ini')
+    HOSTS_CONFIG_FILE = config.get(section, 'hosts_config_file', fallback=CONFIG_FILES.HOSTS_CONFIG_PATH)
     TEST_ON_STARTUP = config.getboolean(section, 'test_on_startup', fallback=True)
     TIMEOUT = config.getfloat(section, 'timeout', fallback=10.0)
     NUM_RETRIES = config.getint(section, 'number_of_retries', fallback=1)

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -2,6 +2,7 @@ from pathlib import PosixPath
 import configparser
 from typing import Dict, Optional, Any, List
 import logging
+import shutil
 import tensorhive
 
 log = logging.getLogger(__name__)
@@ -17,6 +18,39 @@ class CONFIG_FILES:
     tensorhive_package_dir = PosixPath(__file__).parent.parent
     MAIN_CONFIG_TEMPLATE_PATH = str(tensorhive_package_dir / 'main_config.ini')
     HOSTS_CONFIG_TEMPLATE_PATH = str(tensorhive_package_dir / 'hosts_config.ini')
+
+
+class ConfigInitilizer:
+    '''Makes sure that all default config files exist'''
+
+    def __init__(self):
+        # 1. Check if all config files exist
+        both_exist = PosixPath(CONFIG_FILES.MAIN_CONFIG_PATH).exists() and \
+            PosixPath(CONFIG_FILES.HOSTS_CONFIG_PATH).exists()
+
+        if not both_exist:
+            log.warning('[•] One or more default config files not found, recreating...')
+            self.recreate_default_configuration_files()
+
+    def recreate_default_configuration_files(self) -> None:
+        try:
+            # 1. Create directory for stroing config files
+            CONFIG_FILES.config_dir.mkdir(parents=True, exist_ok=True)
+
+            # 2. Clone templates safely from `tensorhive` package
+            self.safe_copy(src=CONFIG_FILES.MAIN_CONFIG_TEMPLATE_PATH, dst=CONFIG_FILES.MAIN_CONFIG_PATH)
+            self.safe_copy(src=CONFIG_FILES.HOSTS_CONFIG_TEMPLATE_PATH, dst=CONFIG_FILES.HOSTS_CONFIG_PATH)
+        except Exception:
+            log.error('[✘] Unable to recreate configuration files.')
+
+    def safe_copy(self, src: str, dst: str) -> None:
+        '''Safe means that it won't override existing configuration'''
+        if PosixPath(dst).exists():
+            log.info('Skipping, file already exists: {}'.format(dst))
+        else:
+            shutil.copy(src, dst)
+            log.info('Copied {} to {}'.format(src, dst))
+
 
 class ConfigLoader:
     @staticmethod


### PR DESCRIPTION
#### Old behavior
Configuration files were copied only once - during `pip install`

#### New behavior
Removed copying config files during `pip install`.
Now, TensorHive checks for their existence at startup.
If some of the default config files is missing, it will be automatically recreated based on `tensorhive` package templates.

#### Future
I think we should allow users to provide a custom path to main config, e.g. `tensorhive --config settings.ini`

#### Side notes
`pip install --editable .` also works.