### PR TITLE
Make database tests a lot faster

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests/
 python_files = *.py
 addopts = --verbose
+env = 
+    PYTEST=1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest==4.0.1
 pytest-faker==2.0.0
+pytest-env==0.6.2
 alembic==1.0.3
 

--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -87,7 +87,7 @@ class DB:
         return 'sqlite:///{}'.format(PosixPath(path).expanduser())
 
     SQLALCHEMY_DATABASE_URI = uri_for_path(config.get(section, 'path', fallback=default_path))
-    TEST_DATABASE_URI = 'sqlite:///test_database.sqlite'  # or 'sqlite://' for in-memory, faster database
+    TEST_DATABASE_URI = 'sqlite://'  # Use in-memory (before: sqlite:///test_database.sqlite)
 
 
 class API:


### PR DESCRIPTION
## Before
1. Using ordinary file database - `test_database.sqlite` -> extremely slow
2. Having to run test, like `PYTEST=1 pytest`

## Now:
1. Using in-memort database => 0.31 s
![image](https://user-images.githubusercontent.com/12485656/49811519-bda38500-fd63-11e8-93ae-2a4c8e763055.png)

2. There's no need to set `PYTEST=1` manually, it's already automated by `pytest.ini`

**Demo**
https://asciinema.org/a/CMv7S8WjzCzJPnh1BFhdyZ7NA

## How to test

Using clean python environment:
```bash
pip install -r requirement-dev.txt
pytest
```

### Future
We need to upgrade our database fixture(s).
Right now each test is isolated (test starts with clean database, which is good in general).
Creating and dropping the database constantly is slow...
We should just redesign this, like flushing db session, or whatever instead.