### PR TITLE
Mailbot rewrite

### DIFF
--- a/tensorhive/config.py
+++ b/tensorhive/config.py
@@ -213,24 +213,12 @@ class MAILBOT:
     NOTIFY_ADMIN = mailbot_config.getboolean(section, 'notify_admin', fallback=False)
     ADMIN_EMAIL = mailbot_config.get(section, 'admin_email', fallback=None)
 
-    # FIXME Not sure if this should be required
     section = 'smtp'
     SMTP_LOGIN = mailbot_config.get(section, 'email', fallback=None)
     SMTP_PASSWORD = mailbot_config.get(section, 'password', fallback=None)
     SMTP_SERVER = mailbot_config.get(section, 'smtp_server', fallback=None)
     SMTP_PORT = mailbot_config.getint(section, 'smtp_port', fallback=587)
 
-    # Simple checks between 'general' and 'smtp' section
-    if PROTECTION_SERVICE.NOTIFY_VIA_EMAIL and (NOTIFY_INTRUDER or NOTIFY_ADMIN):
-        try:
-            assert SMTP_LOGIN and SMTP_PASSWORD and SMTP_SERVER
-        except AssertionError:
-            log.warning('[MAILBOT] Incomplete SMTP configuration, check your config')
-
-        if NOTIFY_ADMIN and not ADMIN_EMAIL:
-            log.warning('[MAILBOT] Invalid admin email address, check your config.')
-
-    # FIXME Not sure if this should be required
     section = 'template/intruder'
     INTRUDER_SUBJECT = mailbot_config.get(section, 'subject')
     INTRUDER_BODY_TEMPLATE = mailbot_config.get(section, 'html_body')

--- a/tensorhive/core/utils/mailer.py
+++ b/tensorhive/core/utils/mailer.py
@@ -19,7 +19,7 @@ class Message:
         msg['From'] = author
         msg['To'] = ', '.join(to) if isinstance(to, list) else to
         msg['Subject'] = subject
-        msg.attach(MIMEText(body, 'html'))
+        msg.attach(MIMEText(body or '', 'html'))
         self.msg = msg
 
     @property

--- a/tensorhive/core/utils/mailer.py
+++ b/tensorhive/core/utils/mailer.py
@@ -68,7 +68,7 @@ class Mailer:
     def __init__(self, server: str, port: int) -> None:
         self.smtp_server = server
         self.smtp_port = port
-        self.server = None
+        self.server = None  # type: smtplib.SMTP
 
     def send(self, message: Message) -> None:
         assert self.server, 'Must call connect() first!'

--- a/tensorhive/core/utils/mailer.py
+++ b/tensorhive/core/utils/mailer.py
@@ -17,7 +17,7 @@ class Message:
     def __init__(self, author: str, to: Union[str, List[str]], subject: str, body: str):
         msg = MIMEMultipart()
         msg['From'] = author
-        msg['To'] = ', '.join(to)
+        msg['To'] = ', '.join(to) if isinstance(to, list) else to
         msg['Subject'] = subject
         msg.attach(MIMEText(body, 'html'))
         self.msg = msg
@@ -52,41 +52,35 @@ class MessageBodyTemplater:
         self.template = template
 
     def fill_in(self, data: Dict[str, Any]) -> str:
-        try:
-            body = self.template.format(
-                hostname=data['HOSTNAME'],
-                gpu_name=data['GPU_NAME'],
-                gpu_uuid=data['UUID'],
-                intruder_username=data['INTRUDER_USERNAME'],
-                intruder_email=data['INTRUDER_EMAIL'],
-                owner_username=data['RESERVATION_OWNER_USERNAME'],
-                owner_email=data['RESERVATION_OWNER_EMAIL'],
-                reservation_end=data['RESERVATION_END'],
-            )
-        except (KeyError, Exception) as e:
-            log.error(e)
-            # Put raw, unformatted body
-            body = self.template
-        finally:
-            return body
+        return self.template.format(
+            hostname=data['HOSTNAME'],
+            gpu_name=data['GPU_NAME'],
+            gpu_uuid=data['UUID'],
+            intruder_username=data['INTRUDER_USERNAME'],
+            intruder_email=data['INTRUDER_EMAIL'],
+            owner_username=data['RESERVATION_OWNER_USERNAME'],
+            owner_email=data['RESERVATION_OWNER_EMAIL'],
+            reservation_end=data['RESERVATION_END'],
+        )
 
 
 class Mailer:
-    def __init__(self, server: str, port: int):
+    def __init__(self, server: str, port: int) -> None:
         self.smtp_server = server
         self.smtp_port = port
+        self.server = None
 
-    def send(self, message: Message):
+    def send(self, message: Message) -> None:
+        assert self.server, 'Must call connect() first!'
+        assert message.author and message.recipients and message.body, 'Incomplete email body: {}'.format(message)
         self.server.sendmail(message.author, message.recipients, message.body)
 
-    def connect(self, login: str, password: str):
-        '''Establishes connection to SMTP server'''
-        try:
-            self.server = smtplib.SMTP(self.smtp_server, self.smtp_port)
-            self.server.starttls()
-            self.server.login(login, password)
-        except Exception as e:
-            log.error(e)
+    def connect(self, login: str, password: str) -> None:
+        # assert login and password, 'Login and password must not be None!'
+        # assert self.smtp_server and self.smtp_port, 'SMTP server and port must not be None!'
+        self.server = smtplib.SMTP(self.smtp_server, self.smtp_port)
+        self.server.starttls()
+        self.server.login(login, password)
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         self.server.close()

--- a/tensorhive/core/violation_handlers/EmailSendingBehaviour.py
+++ b/tensorhive/core/violation_handlers/EmailSendingBehaviour.py
@@ -2,145 +2,119 @@ from tensorhive.core.utils.decorators.override import override
 from sqlalchemy.orm.exc import NoResultFound
 from tensorhive.models.User import User
 from typing import Generator, Dict, List, Any, Optional
-from tensorhive.config import MAILBOT
+from tensorhive.config import MAILBOT, CONFIG_FILES
 from tensorhive.core.utils.mailer import Mailer, Message, MessageBodyTemplater
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from inspect import cleandoc
 import datetime
 import smtplib
-import os
 import logging
 log = logging.getLogger(__name__)
 
 
-class EmailSendingBehaviour:
-    message = cleandoc('''
-                You are violating {legitimate_owner_username}\'s reservation!
-                Please, stop all your computations on {gpu_uuid}.
-                ''')
+class LastEmailTime:
+    '''TODO'''
 
     def __init__(self):
-        self.interval = datetime.timedelta(minutes=MAILBOT.INTERVAL)
-        self.time_of_last_email = {}
+        self.to_admin = datetime.datetime.min
+        self.to_intruder = datetime.datetime.min
+
+
+class EmailSendingBehaviour:
+    '''TODO'''
+
+    def __init__(self) -> None:
+        '''TODO'''
         self.mailer = Mailer(server=MAILBOT.SMTP_SERVER, port=MAILBOT.SMTP_PORT)
+        self.test_smtp_configuration()
+        self.interval = datetime.timedelta(minutes=MAILBOT.INTERVAL)
+        self.timers = {}
 
-    def filter_sessions(self, violation_data):
-        result = []
-        # self.time_between_notifications = time_left
-        return result
-
-    def prepare_intruder_message(self, violation_data: Dict[str, Any], recipients: List[str]) -> Message:
-        email_body = MessageBodyTemplater(
-            template=MAILBOT.INTRUDER_BODY_TEMPLATE
-        ).fill_in(data=violation_data)
-
-        return Message(
-            author=MAILBOT.SMTP_LOGIN,
-            to=recipients,
-            subject=MAILBOT.INTRUDER_SUBJECT,
-            body=email_body
-        )
-
-    def prepare_admin_message(self, violation_data: Dict[str, Any], recipients: List[str]) -> Message:
-        email_body = MessageBodyTemplater(
-            template=MAILBOT.INTRUDER_BODY_TEMPLATE
-        ).fill_in(data=violation_data)
-
-        return Message(
-            author=MAILBOT.SMTP_LOGIN,
-            to=recipients,
-            subject=MAILBOT.INTRUDER_SUBJECT,
-            body=email_body
-        )
-
-    def fetch_email_address(self, username: str) -> Optional[str]:
-        email = None
-        try:
-            intruder = User.find_by_username(username)
-        except NoResultFound:
-            # User does not exist or has no email address
-            pass
-        except Exception as e:
-            log.critical(e)
+    def time_to_resend(self, timer: LastEmailTime, to_admin: Optional[bool] = False) -> bool:
+        '''TODO'''
+        if to_admin:
+            last_notification_time = timer.to_admin
         else:
-            email = intruder.email
-        finally:
-            return email
+            last_notification_time = timer.to_intruder
+        return last_notification_time + self.interval <= datetime.datetime.utcnow()
 
-    def ready_to_send(self, email_address: str) -> bool:
-        '''
-        Allows for sending email only once every given time
-        to a particular email address
-        '''
+    def get_timer(self, keyname: str) -> Dict[str, datetime.datetime]:
+        '''TODO'''
         try:
-            ready_status = self.time_of_last_email[email_address] + self.interval < datetime.datetime.utcnow()
+            timer = self.timers[keyname]
         except KeyError:
-            ready_status = True
-        finally:
-            return ready_status
+            self.timers[keyname] = LastEmailTime()
+            return self.timers[keyname]
+        else:
+            return timer
 
-    # TODO Refactor these two clunky, redundant methods
-    def send_email_to_intruder(self, violation_data: Dict[str, Any]):
-        author = MAILBOT.SMTP_LOGIN
-        recipient = violation_data['INTRUDER_EMAIL']
+    def test_smtp_configuration(self) -> bool:
+        try:
+            assert MAILBOT.SMTP_SERVER and MAILBOT.SMTP_PORT, 'Incomplete SMTP server configuration'
+            assert MAILBOT.SMTP_LOGIN and MAILBOT.SMTP_PASSWORD, 'Incomplete SMTP server credentials'
+            if MAILBOT.NOTIFY_ADMIN:
+                assert MAILBOT.ADMIN_EMAIL, 'Admin contact email not specified despite enabled notifications'
+
+            self.mailer.connect(login=MAILBOT.SMTP_LOGIN, password=MAILBOT.SMTP_PASSWORD)
+        except AssertionError as e:
+            log.error('{}, please check your config: {}'.format(e, CONFIG_FILES.MAILBOT_CONFIG_PATH))
+            return False
+        except smtplib.SMTPException as e:
+            log.error(e)
+            return False
+        else:
+            return True
+
+    def email_intruder(self, email: str, violation_data: Dict, timer: LastEmailTime) -> None:
         email_body = MessageBodyTemplater(template=MAILBOT.INTRUDER_BODY_TEMPLATE).fill_in(data=violation_data)
-
-        email = Message(
-            author=author,
-            to=[recipient],
-            subject=MAILBOT.INTRUDER_SUBJECT,
-            body=email_body
-        )
+        email = Message(author=MAILBOT.SMTP_LOGIN, to=email, subject=MAILBOT.INTRUDER_SUBJECT, body=email_body)
         self.mailer.send(email)
-        self.time_of_last_email[recipient] = datetime.datetime.utcnow()
-        log.warning('Email sent to: {}'.format(recipient))
+        timer.to_intruder = datetime.datetime.utcnow()
+        log.info('Email to intruder has been sent: {}'.format(email))
 
-    def send_email_to_admin(self, violation_data: Dict[str, Any]):
-        author = MAILBOT.SMTP_LOGIN
-        recipient = MAILBOT.ADMIN_EMAIL
+    def email_admin(self, violation_data: Dict, timer: LastEmailTime) -> None:
         email_body = MessageBodyTemplater(template=MAILBOT.ADMIN_BODY_TEMPLATE).fill_in(data=violation_data)
-
-        email = Message(
-            author=author,
-            to=[recipient],
-            subject=MAILBOT.ADMIN_SUBJECT,
-            body=email_body
-        )
+        email = Message(author=MAILBOT.SMTP_LOGIN, to=MAILBOT.ADMIN_EMAIL,
+                        subject=MAILBOT.ADMIN_SUBJECT, body=email_body)
         self.mailer.send(email)
-        self.time_of_last_email[recipient] = datetime.datetime.utcnow()
-        log.warning('Email sent to: {}'.format(recipient))
+        timer.to_admin = datetime.datetime.utcnow()
+        log.info('Email to admin has been sent: {}'.format(email))
 
     @override
-    def trigger_action(self, violation_data: Dict[str, Any]):
+    def trigger_action(self, violation_data: Dict[str, Any]) -> None:
+        '''TODO'''
         # Expect proper keys beforehand
-        assert set([
+        assert {
             'INTRUDER_USERNAME',
             'RESERVATION_OWNER_USERNAME',
             'RESERVATION_OWNER_EMAIL',
             'RESERVATION_END',
             'UUID',
-            'HOSTNAME']).issubset(violation_data), 'Invalid keys in violation_data'
-        # Initialize mailer connection
-        self.mailer.connect(
-            login=MAILBOT.SMTP_LOGIN,
-            password=MAILBOT.SMTP_PASSWORD
-        )
+            'HOSTNAME'}.issubset(violation_data), 'Invalid keys in violation_data'
+
+        if not self.test_smtp_configuration():
+            return
+
         try:
-            # Fetch and store intruder's email
-            intruder_email = self.fetch_email_address(username=violation_data['INTRUDER_USERNAME'])
+            # Fetch email address and extend violation data
+            intruder_email = User.find_by_username(violation_data['INTRUDER_USERNAME']).email
+        except NoResultFound as e:
+            intruder_email = None
+            log.warning(e)
+        finally:
             violation_data['INTRUDER_EMAIL'] = intruder_email
 
-            # Send emails
-            if intruder_email and self.ready_to_send(intruder_email):
-                self.send_email_to_intruder(violation_data)
-            if MAILBOT.NOTIFY_ADMIN and self.ready_to_send(MAILBOT.ADMIN_EMAIL):
-                self.send_email_to_admin(violation_data)
-        except AssertionError:
-            pass
-        except Exception as e:
-            log.critical(e)
-            import traceback
-            traceback.print_exc()
-        else:
-            self.mailer.disconnect()
+        if not intruder_email:
+            # At least try notify admin
+            timer = self.get_timer(violation_data['INTRUDER_USERNAME'])
+            if MAILBOT.NOTIFY_ADMIN and self.time_to_resend(timer, to_admin=True):
+                self.email_admin(violation_data, timer)
+            return
+
+        # Try email both
+        timer = self.get_timer(intruder_email)
+        if MAILBOT.NOTIFY_INTRUDER and self.time_to_resend(timer):
+            self.email_intruder(intruder_email, violation_data, timer)
+        if MAILBOT.NOTIFY_ADMIN and self.time_to_resend(timer, to_admin=True):
+            self.email_admin(violation_data, timer)

--- a/tests/unit/test_mailbot.py
+++ b/tests/unit/test_mailbot.py
@@ -1,0 +1,76 @@
+from tensorhive.core.violation_handlers.EmailSendingBehaviour import EmailSendingBehaviour
+from tensorhive.models.User import User
+from tensorhive.config import MAILBOT
+from tensorhive.core.utils.mailer import MessageBodyTemplater, Message, Mailer
+from datetime import datetime
+from unittest.mock import patch
+from typing import Any
+import pytest
+import email
+
+
+@pytest.yield_fixture()
+def violation_data():
+    return {
+        'INTRUDER_USERNAME': 'intruder_email_mock',
+        'RESERVATION_OWNER_USERNAME': 'owner_username_mock',
+        'RESERVATION_OWNER_EMAIL': 'owner_email_mock',
+        'RESERVATION_END': 'datetime_mock',
+        'UUID': 'uuid_mock_' * 4,
+        'GPU_NAME': 'GPU mock',
+        'HOSTNAME': 'Hostname mock'
+    }
+
+
+def test_mailer_when_try_to_send_before_connect():
+    with pytest.raises(AssertionError):
+        Mailer('foo', 123).send('foo')
+
+
+def test_mailer_sending_with_invalid_message():
+    with patch('smtplib.SMTP') as mock_smtp:
+        mailer = Mailer('foo', 123)
+        mailer.connect(login=Any, password=Any)
+        with pytest.raises(AssertionError):
+            message = Message(None, None, None, None)
+            mailer.send(message)
+
+
+def test_building_message():
+    # Single recipient
+    message = Message(author='foo', to='bar', subject='foo', body='bar')
+    assert message.author == 'foo'
+    assert message.recipients == 'bar'
+    assert message.subject == 'foo'
+    assert isinstance(message.msg, email.mime.multipart.MIMEMultipart)
+    assert isinstance(message.body, str)
+
+    # Multiple recipients
+    message = Message(author='foo', to=['foo', 'bar', 'fizz'], subject='foo', body='bar')
+    assert message.recipients == 'foo, bar, fizz'
+
+
+def test_message_sending():
+    with patch('smtplib.SMTP') as mock_smtp:
+        mailer = Mailer('foo', 123)
+        message = Message(author='foo', to='bar', subject='foo', body='bar')
+
+        mailer.server = mock_smtp.return_value
+        mailer.send(message)
+        assert mailer.server.sendmail.call_count == 1
+
+# Test that send real email (must check manually for now)
+# def test_email_sending(violation_data):
+#     MAILBOT.SMTP_SERVER = 'smtp.gmail.com'
+#     MAILBOT.SMTP_PORT = 587
+#     MAILBOT.SMTP_LOGIN = 'tensorhive.mailbot@gmail.com'
+#     MAILBOT.SMTP_PASSWORD = '===REPLACE ME WITH REAL PASSWORD==='
+
+#     MAILBOT.NOTIFY_ADMIN = True
+#     MAILBOT.ADMIN_EMAIL = 'tensorhive.mailbot@gmail.com'
+#     with patch.object(User, 'find_by_username') as mock_intruder:
+#         mock_intruder.return_value.email = 'tensorhive.mailbot@gmail.com'
+#         mailbot = EmailSendingBehaviour()
+#         with patch.object(mailbot, '_time_to_resend') as mock_resend:
+#             mock_resend.return_value = True
+#             mailbot.trigger_action(violation_data)

--- a/tests/unit/test_mailbot.py
+++ b/tests/unit/test_mailbot.py
@@ -36,7 +36,7 @@ def test_mailer_sending_with_invalid_message():
             mailer.send(message)
 
 
-def test_building_message():
+def test_message_properly_processes_init_arguments():
     # Single recipient
     message = Message(author='foo', to='bar', subject='foo', body='bar')
     assert message.author == 'foo'
@@ -50,7 +50,7 @@ def test_building_message():
     assert message.recipients == 'foo, bar, fizz'
 
 
-def test_message_sending():
+def test_sendmail_is_reached_with_mock_smtp_server():
     with patch('smtplib.SMTP') as mock_smtp:
         mailer = Mailer('foo', 123)
         message = Message(author='foo', to='bar', subject='foo', body='bar')
@@ -60,7 +60,7 @@ def test_message_sending():
         assert mailer.server.sendmail.call_count == 1
 
 # Test that send real email (must check manually for now)
-# def test_email_sending(violation_data):
+# def test_sending_real_email_to_inbox(violation_data):
 #     MAILBOT.SMTP_SERVER = 'smtp.gmail.com'
 #     MAILBOT.SMTP_PORT = 587
 #     MAILBOT.SMTP_LOGIN = 'tensorhive.mailbot@gmail.com'


### PR DESCRIPTION
* Each intruder has separate timer for admin notifications (so he don't get spammed so badly)
* Every step of mailbot configuration is verified periodically at runtime (`log.error()`)
* Intruders without TH account (or email) will not be notified (of course), but **admin will**!

* Basic tests included (+ one that actually sends real email - see commented out `test_sending_real_email_to_inbox`)

Fixed issues: #149 #145 