### PR TITLE
Add tail mode and refresh feature to the log preview

### DIFF
--- a/tensorhive/app/web/dev/src/components/views/TasksOverview.vue
+++ b/tensorhive/app/web/dev/src/components/views/TasksOverview.vue
@@ -40,7 +40,13 @@
       :multipleFlag="multipleFlag"
       :selected="selected"
     />
-    <TaskLog :show-modal="showModalLog" @close="showModalLog = false" :lines="logs" :path="path" />
+    <TaskLog
+      :show-modal="showModalLog"
+      @close="showModalLog = false"
+      @getLog="getLog(...arguments)"
+      :lines="logs"
+      :path="path"
+      :taskId="taskId"/>
     <v-dialog v-model="showModalHowItWorks" width="500">
       <v-card>
         <v-card-text class="headline grey lighten-2" primary-title>
@@ -587,27 +593,26 @@ export default {
       }
     },
 
-    getLog: function (id) {
+    getLog: function (id, tailMode = false) {
+      this.taskId = id
       if (!this.actionFlag) {
         this.snackbar = true
         this.actionFlag = true
         api
-          .request('get', '/tasks/' + id + '/log', this.$store.state.accessToken)
+          .request('get', '/tasks/' + id + '/log?tail=' + tailMode, this.$store.state.accessToken)
           .then(response => {
             this.logs = response.data.output_lines
             this.path = response.data.path
             this.showModalLog = true
-            this.snackbar = false
-            this.actionFlag = false
           })
           .catch(error => {
             this.handleError(error)
+          }).finally(() => {
             this.snackbar = false
             this.actionFlag = false
           })
       }
     },
-
     openFromTemplate: function (chosenTemplate) {
       this.chosenTemplate = chosenTemplate
       this.showModalCreate = true

--- a/tensorhive/app/web/dev/src/components/views/tasks_overview/TaskLog.vue
+++ b/tensorhive/app/web/dev/src/components/views/tasks_overview/TaskLog.vue
@@ -14,7 +14,36 @@
         >
           <v-icon>close</v-icon>
         </v-btn>
-        <span class="headline">Task log</span>
+        <span class="headline">
+          Task log
+          <v-btn
+            flat
+            icon
+            color="green"
+            @click="refresh()">
+            <v-icon>refresh</v-icon>
+          </v-btn>
+        </span>
+        <span class="subheading">
+          <v-checkbox
+            flat
+            style="display: inline"
+            label="Tail mode"
+            v-model="tailMode"
+            @click="refresh"
+            hide-details
+           />
+          <v-checkbox
+            flat
+            style="display: inline"
+            label="Auto-refresh"
+            v-model="autoRefresh"
+            v-on="on"
+            :disabled="!tailMode"
+            @click="toggleAutoRefresh"
+            hide-details
+          />
+        </span>
       </v-card-text>
       <v-card-text>
         {{path}}
@@ -33,11 +62,15 @@ export default {
   props: {
     showModal: Boolean,
     lines: Array,
-    path: String
+    path: String,
+    taskId: Number
   },
   data () {
     return {
-      show: false
+      show: false,
+      tailMode: false,
+      autoRefresh: false,
+      autoRefreshIntervalId: -1
     }
   },
   watch: {
@@ -51,6 +84,21 @@ export default {
   methods: {
     close: function () {
       this.$emit('close')
+    },
+    refresh: function () {
+      this.$emit('getLog', this.taskId, this.tailMode)
+      if (this.autoRefresh && !this.tailMode) {
+        this.autoRefresh = false
+        this.toggleAutoRefresh()
+      }
+    },
+    toggleAutoRefresh: function () {
+      if (this.autoRefresh) {
+        this.autoRefreshIntervalId = window.setInterval(this.refresh, 5000)
+      } else {
+        window.clearInterval(this.autoRefreshIntervalId)
+        this.autoRefreshIntervalId = -1
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes: #201 

- Added refresh button to let the user refresh logs on demand
- Added tail mode checkbox in the frontend (upon checking the box the logs automatically refresh to reflect the changed mode)
- Added auto-refresh feature for when the tail mode is enabled (every 5 seconds).

![image](https://user-images.githubusercontent.com/16022081/76625170-f6b64080-6536-11ea-9fcd-9cb4e807c421.png)

![image](https://user-images.githubusercontent.com/16022081/76625197-05045c80-6537-11ea-9826-04bc2f282201.png)


